### PR TITLE
Upgrade debug to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/stdarg/spdx-licenses",
   "dependencies": {
-    "debug": "4.1.1,
+    "debug": "4.1.1",
     "is2": "0.0.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/stdarg/spdx-licenses",
   "dependencies": {
-    "debug": "0.7.4",
+    "debug": "4.1.1,
     "is2": "0.0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
older versions are vulnerable to [CVE-2017-16137](https://nvd.nist.gov/vuln/detail/CVE-2017-16137)